### PR TITLE
mic button does not update during a scroll event

### DIFF
--- a/Wit/WITRecorder.m
+++ b/Wit/WITRecorder.m
@@ -166,7 +166,7 @@ static void MyPropertyListener(void *userData, AudioQueueRef queue, AudioQueuePr
     // init recorder
     displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updatePower)];
     [displayLink setPaused:YES];
-    [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
 
     // create audio session
     AVAudioSession* session = [AVAudioSession sharedInstance];


### PR DESCRIPTION
This change makes the mic button update it's power during a scroll event. A displaylink attached to the default runloop mode does not update during scroll events, therefore the power notifications are not fired.