### PR TITLE
WitContextSetter initialised lazily / preventing alert on startup 

### DIFF
--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -16,7 +16,7 @@
 
 @interface Wit : NSObject  <WITRecordingSessionDelegate>
 
-@property(strong) WITContextSetter *wcs;
+@property(strong, readonly) WITContextSetter *wcs;
 
 /**
  Delegate to send feedback for the application


### PR DESCRIPTION
I had the problem that iOS always displayed an alert to ask for the location-service permission on startup of my app. This was triggered by Wit which accessed the location service during initialisation and long before Wit was effectively used.

This fix delays the initialisation of the WITContextSetter until when it's effectively used and the alert shows up much later.