### PR TITLE
Wit is not called from WITMicButton anymore when RecordPermission is not granted.

### DIFF
--- a/Wit/WITMicButton.m
+++ b/Wit/WITMicButton.m
@@ -229,7 +229,19 @@ static const CGFloat kMicMargin = 40.0f;
 
 #pragma mark - UIButton target
 - (void)buttonPressed:(id)sender {
-    [[Wit sharedInstance] toggleCaptureVoiceIntent:self];
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    Wit *wit = [Wit sharedInstance];
+
+    if ([audioSession respondsToSelector:@selector(requestRecordPermission:)]) {
+        [audioSession requestRecordPermission:^(BOOL granted) {
+            if (granted) {
+                [wit toggleCaptureVoiceIntent:self];
+            }
+        }];
+    }
+    else{
+        [wit toggleCaptureVoiceIntent:self];
+    }
 }
 
 #pragma mark - NSNoticationCenter


### PR DESCRIPTION
I had the problem that WITMicButton would call into Wit even when the RecordPermission was Denied or Undeterminded.  This resulted in an error being returned in witDidGraspIntent (I assume because invalid data would have been uploaded to Wit). The RecordPermission can't be requested outside of WITMicButton because that would trigger the permission alert even though the user didn't press the mic button.

This fix solves the problem by not calling into to Wit when the RecordPermission is not granted.