### PR TITLE
VAD Speech Detection Scope, Callback

### DIFF
--- a/Wit/WITRecordingSession.h
+++ b/Wit/WITRecordingSession.h
@@ -38,6 +38,7 @@
 -(void)recordingSessionActivityDetectorStarted;
 -(void)recordingSessionDidStartRecording;
 -(void)recordingSessionDidStopRecording;
+-(void)recordingSessionDidDetectSpeech;
 -(void)recordingSessionRecorderGotChunk:(NSData*)chunk;
 -(void)recordingSessionGotResponse:(NSDictionary*)resp customData:(id)customData error:(NSError*)err;
 

--- a/Wit/WITRecordingSession.m
+++ b/Wit/WITRecordingSession.m
@@ -115,6 +115,8 @@ WITContextSetter *wcs;
 }
 
 -(void)recorderDetectedSpeech {
+    [self.delegate recordingSessionDidDetectSpeech];
+    
     if (self.vadEnabled == WITVadConfigFull) {
         dispatch_async(dispatch_get_main_queue(), ^{
             //start the uploader

--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -17,6 +17,8 @@
 
 @interface Wit : NSObject  <WITRecordingSessionDelegate>
 
+@property(nonatomic, strong) WITRecordingSession *recordingSession;
+
 @property(strong, readonly) WITContextSetter *wcs;
 
 /**

--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -151,6 +151,11 @@
 - (void)witDidStopRecording;
 
 /**
+ Called when Wit detects speech from the audio input.
+ */
+- (void)witDidDetectSpeech;
+
+/**
  Called whenever Wit reveices an audio chunk. The format of the returned audio is 16-bit PCM, 16 kHz mono.
  */
 - (void)witDidGetAudio:(NSData *)chunk;

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -224,6 +224,12 @@
     }
 }
 
+-(void)recordingSessionDidDetectSpeech {
+    if ([self.delegate respondsToSelector:@selector(witDidDetectSpeech)]) {
+        [self.delegate witDidDetectSpeech];
+    }
+}
+
 -(void)recordingSessionRecorderGotChunk:(NSData *)chunk {
     if ([self.delegate respondsToSelector:@selector(witDidGetAudio:)]) {
         [self.delegate witDidGetAudio:chunk];

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -14,7 +14,6 @@
 
 @interface Wit ()
 @property (strong) WITState *state;
-@property WITRecordingSession *recordingSession;
 @end
 
 @implementation Wit {


### PR DESCRIPTION
Changing the scope of the recordingSession property to public allows access to the following property:
`[Wit sharedInstance].recordingSession.recorder.stoppedUsingVad`

This is useful for playing a confirmation sound effect after voice capture is stopped so the user knows his/her voice command was received.

==========

The new delegate methods allow for triggering actions when a user begins speaking a voice command. This is useful when `toggleCaptureVoiceIntent` is manually triggered to start listening and you want to perform an action if and when the user begins speaking a voice command.