### PR TITLE
Speech recognition for converse endpoint

### DIFF
--- a/Wit/WITMicButton.h
+++ b/Wit/WITMicButton.h
@@ -17,6 +17,9 @@
 @property (nonatomic, strong) CALayer* microphoneLayer;
 @property (nonatomic, strong) WITCircleView* outerCircleView;
 @property (nonatomic, strong) WITCircleView* innerCircleView;
+/**
+ If you have a override-microphone.png in your mainbundle then that image will be used for the mic button, else the default image from the framework will be used.
+ */
 @property (nonatomic, strong) CALayer* micMask;
 
 - (void)newAudioLevel:(NSNotification*)n;

--- a/Wit/WITMicButton.h
+++ b/Wit/WITMicButton.h
@@ -11,12 +11,14 @@
 #import "WITCircleLayer.h"
 #import "WITCircleView.h"
 #import "WITRecorder.h"
+#import "WitSession.h"
 
 @interface WITMicButton : UIButton
 @property (nonatomic, strong) CALayer* volumeLayer;
 @property (nonatomic, strong) CALayer* microphoneLayer;
 @property (nonatomic, strong) WITCircleView* outerCircleView;
 @property (nonatomic, strong) WITCircleView* innerCircleView;
+@property (nonatomic, strong) WitSession *session;
 /**
  If you have a override-microphone.png in your mainbundle then that image will be used for the mic button, else the default image from the framework will be used.
  */

--- a/Wit/WITMicButton.m
+++ b/Wit/WITMicButton.m
@@ -46,17 +46,16 @@ static const CGFloat kMicMargin = 40.0f;
     self.innerCircleView.fillColor = [UIColor whiteColor];;
     
     // microphone mask
-    // try to find image in mainBundle (CocoaPods), then frameworkBundle (.framework)
-    UIImage *micUIImage = [UIImage imageNamed:@"microphoneWave.png"];
+    // try to find image override image mainBundle (CocoaPods), then default image in frameworkBundle (.framework)
+    UIImage *micUIImage = [UIImage imageNamed:@"override-microphone.png"];
     if (!micUIImage) {
-        NSString* path = [[WITState frameworkBundle] pathForResource:kMicrophoneImage ofType:nil];
-        micUIImage = [UIImage imageWithContentsOfFile:path];
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        micUIImage = [UIImage imageNamed:@"microphone.png" inBundle:bundle compatibleWithTraitCollection:nil];
         
         if (!micUIImage) {
-            NSLog(@"Wit: couldn't find microphone image: %@", kMicrophoneImage);
+            NSLog(@"Wit: couldn't find microphone image: %@", @"microphone.png");
         }
-    }
-    CGImageRef micImage = micUIImage.CGImage;
+    }    CGImageRef micImage = micUIImage.CGImage;
     self.micMask = [CALayer layer];
     self.micMask.contents = (__bridge id)micImage;
     

--- a/Wit/WITMicButton.m
+++ b/Wit/WITMicButton.m
@@ -225,14 +225,14 @@ static const CGFloat kMicMargin = 40.0f;
     if ([audioSession respondsToSelector:@selector(requestRecordPermission:)]) {
         [audioSession requestRecordPermission:^(BOOL granted) {
             if (granted) {
-                [wit toggleCaptureVoiceIntent:self];
+                [wit toggleCaptureVoiceIntent:self.session];
             } else {
                 NSLog(@"No mic permission, sorry");
             }
         }];
     }
     else{
-        [wit toggleCaptureVoiceIntent:self];
+        [wit toggleCaptureVoiceIntent:self.session];
     }
 }
 

--- a/Wit/WITRecordingSessionDelegate.h
+++ b/Wit/WITRecordingSessionDelegate.h
@@ -14,7 +14,7 @@
 -(void)recordingSessionDidStartRecording;
 -(void)recordingSessionDidStopRecording;
 - (void) recordingSessionReceivedError: (NSError *) error;
--(void)recordingSessionDidRecognizePreviewText: (NSString *) previewText;
+-(void)recordingSessionDidRecognizePreviewText: (NSString *) previewText final: (BOOL) isFinal;
 -(void)recordingSessionDidDetectSpeech;
 -(void)recordingSessionRecorderGotChunk:(NSData *)chunk;
 -(void)recordingSessionGotResponse:(NSDictionary *)resp customData:(id)customData error:(NSError *)err sender:(id) sender;

--- a/Wit/WITSFSpeechRecordingSession.h
+++ b/Wit/WITSFSpeechRecordingSession.h
@@ -10,5 +10,5 @@
 #import "WITRecordingSession.h"
 
 @interface WITSFSpeechRecordingSession : WITRecordingSession
-
+-(instancetype)initWithWitContext:(NSDictionary *)upContext vadEnabled:(WITVadConfig)vadEnabled withWitToken:(NSString *)witToken customData: (id) customData withDelegate:(id<WITRecordingSessionDelegate>)delegate;
 @end

--- a/Wit/WITSFSpeechRecordingSession.m
+++ b/Wit/WITSFSpeechRecordingSession.m
@@ -161,7 +161,7 @@
     [inputNode installTapOnBus:0 bufferSize:1024 format:recordingFormat block:^(AVAudioPCMBuffer * _Nonnull buffer, AVAudioTime * _Nonnull when) {
         [recognitionRequest appendAudioPCMBuffer:buffer];
         
-        NSData* audio = [NSData dataWithBytes:buffer.audioBufferList->mBuffers[0].mData length:buffer.audioBufferList->mBuffers[0].mDataByteSize];
+        //NSData* audio = [NSData dataWithBytes:buffer.audioBufferList->mBuffers[0].mData length:buffer.audioBufferList->mBuffers[0].mDataByteSize];
        // [self.vad gotAudioSamples:audio];
         
         UInt32 inNumberFrames = buffer.frameLength;

--- a/Wit/WITSFSpeechRecordingSession.m
+++ b/Wit/WITSFSpeechRecordingSession.m
@@ -107,12 +107,14 @@
     NSLog(@"START CALLED");
       NSError *error;
     
+    /*
     AVAudioSession *audiosession = [AVAudioSession sharedInstance];
    
     [audiosession setMode: AVAudioSessionModeMeasurement error:&error];
     if (error) {
         NSLog(@"mode error was %@", error);
     }
+     */
      /*
     [audiosession setActive:YES withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
     if (error) {

--- a/Wit/WITState.h
+++ b/Wit/WITState.h
@@ -10,7 +10,6 @@
 #import "WITRecorder.h"
 
 @interface WITState : NSObject
-@property (nonatomic, copy) NSString* resourcePath;
 @property (nonatomic, strong) WITRecorder* recorder;
 @property (nonatomic, strong) WITUploader* uploader;
 @property (nonatomic, copy) NSString *accessToken;
@@ -18,5 +17,4 @@
 
 + (WITState *)sharedInstance;
 + (NSString *)UUID;
-+ (NSBundle *)frameworkBundle;
 @end

--- a/Wit/WITState.m
+++ b/Wit/WITState.m
@@ -26,7 +26,7 @@
     static NSBundle* frameworkBundle = nil;
     static dispatch_once_t predicate;
     dispatch_once(&predicate, ^{
-        NSString* mainBundlePath = [[NSBundle mainBundle] resourcePath];
+        NSString* mainBundlePath = [[NSBundle bundleForClass:[self class]] resourcePath];
         NSString* frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"Wit.bundle"];
         frameworkBundle = [NSBundle bundleWithPath:frameworkBundlePath];
     });

--- a/Wit/WITState.m
+++ b/Wit/WITState.m
@@ -22,16 +22,6 @@
 }
 
 // Load the framework bundle.
-+ (NSBundle *)frameworkBundle {
-    static NSBundle* frameworkBundle = nil;
-    static dispatch_once_t predicate;
-    dispatch_once(&predicate, ^{
-        NSString* mainBundlePath = [[NSBundle bundleForClass:[self class]] resourcePath];
-        NSString* frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"Wit.bundle"];
-        frameworkBundle = [NSBundle bundleWithPath:frameworkBundlePath];
-    });
-    return frameworkBundle;
-}
 
 #pragma mark - Defaults
 - (void)readPlist {
@@ -55,7 +45,6 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _resourcePath = [[self.class frameworkBundle] resourcePath];
         [self readPlist];
         _context = [[NSDictionary alloc] init];
     }

--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -220,7 +220,7 @@
 /**
  Called whenever SFSpeech sends a recognition preview of the recording.
  */
-- (void) witDidRecognizePreviewText: (NSString *) previewText;
+- (void) witDidRecognizePreviewText: (NSString *) previewText final: (BOOL) isFinal;
 
 - (void) witReceivedRecordingError: (NSError *) error;
 

--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -169,6 +169,14 @@
 - (void) didStopSession: (WitSession *) session;
 
 /**
+ Called when you receive an error from the converse endpoint. Implementing this is required if you are using the converse api.
+
+ @param error The NSError you received.
+ @param session The session that received the error.
+ */
+- (void) didReceiveConverseError: (NSError *) error witSession: (WitSession *) session;
+
+/**
  * Called when a Wit request is completed. This is only called for legacy calls to interpretString (which uses the deprecated get /intent API). If you are using Wit stories (the post /converse API), use didReceiveAction, didReceiveMessage and didReceiveStop instead.
  * param outcomes a NSDictionary of outcomes returned by the Wit API. Outcomes are ordered by confidence, highest first. Each outcome contains (at least) the following keys:
  *       intent, entities[], confidence, _text. For more information please refer to our online documentation: https://wit.ai/docs/http/20141022#get-intent-via-text-link

--- a/Wit/Wit.h
+++ b/Wit/Wit.h
@@ -130,7 +130,18 @@
 @optional
 
 /**
- Called when your story triggers an action and includes any new entities from Wit. Update session.context with any keys required for the next step of the story and return it here, wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method.
+ Called when your story triggers a merge and includes any new entities from Wit. Update session.context with any keys required for the next step of the story and return it here, wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method. In many cases may wish to call simply call your didReceiveAction implementation and handle the merge there. Implementing this is required if you are using the converse api.
+ 
+ @param entities Any entities Wit found, as specified in your story.
+ @param session The previous WitSession object. Update session.context with any context changes (these will be sent to the Wit server) and optionally store any futher data in session.customData (this will not be sent to the Wit server) and return this WitSession.
+ @param confidence The confidence that Wit correctly guessed the users intent, between 0.0 and 1.0
+ @return The WitSession to continue. Update the session parameter and return it. Returning nil is considered an error.
+ */
+- (WitSession *) didReceiveMergeEntities: (NSDictionary *) entities witSession: (WitSession *) session confidence: (double) confidence;
+
+
+/**
+ Called when your story triggers an action and includes any new entities from Wit. Update session.context with any keys required for the next step of the story and return it here, wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method. Implementing this is required if you are using the converse api.
 
  @param action The action to perform, as specified in your story.
  @param entities Any entities Wit found, as specified in your story.
@@ -141,7 +152,7 @@
 - (WitSession *) didReceiveAction: (NSString *) action entities: (NSDictionary *) entities witSession: (WitSession *) session confidence: (double) confidence;
 
 /**
- Called when your story wants your app to display a message. Update session.context with any keys required for the next step of the story and return it here, wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method. wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method.
+ Called when your story wants your app to display a message. Update session.context with any keys required for the next step of the story and return it here, wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method. wit-ios-sdk will automatically perform the next converse request for you and call the appropriate delegate method. Implementing this is required if you are using the converse api.
 
  @param message The message to display
  @param session The previous WitSession object. Update session.context with any context changes (these will be sent to the Wit server) and optionally store any futher data in session.customData (this will not be sent to the Wit server) and return this WitSession.
@@ -151,7 +162,7 @@
 - (WitSession *) didReceiveMessage: (NSString *) message quickReplies: (NSArray *) quickReplies witSession: (WitSession *) session confidence: (double) confidence;
 
 /**
- Called when your story has completed.
+ Called when your story has completed. Implementing this is required if you are using the converse api.
 
  @param session The WitSession passed in from your last delegate call.
  */

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -238,6 +238,9 @@
         [self.delegate didStopSession:customData];
         return;
         
+    } else if ([type isEqualToString:@"merge"])  {
+        session = [self.delegate didReceiveMergeEntities:response[@"entities"] witSession:session confidence:[response[@"confidence"] doubleValue]];
+        
     }
     NSAssert(session != nil, @"You need to return the WitSession from your delegate call.");
     

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -70,7 +70,7 @@
     NSString *urlString = [NSString stringWithFormat:@"https://api.wit.ai/message?q=%@&v=%@&context=%@&verbose=true", urlencodeString(string), kWitAPIVersion, contextEncoded];
     NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString: urlString]];
     [req setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
-    [req setTimeoutInterval:15.0];
+    [req setTimeoutInterval:30.0];
     [req setValue:[NSString stringWithFormat:@"Bearer %@", self.accessToken] forHTTPHeaderField:@"Authorization"];
     [req setValue:@"application/json" forHTTPHeaderField:@"Accept"];
 

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -44,7 +44,7 @@
     if ([SFSpeechRecognizer class]) {
         self.recordingSession = [[WITSFSpeechRecordingSession alloc] initWithWitContext:self.state.context
                                                                      vadEnabled:[Wit sharedInstance].detectSpeechStop withWitToken:[WITState sharedInstance].accessToken
-                                                                   withDelegate:self];
+                                                                             customData: customData withDelegate:self];
     } else {
         self.recordingSession = [[WITRecordingSession alloc] initWithWitContext:self.state.context
                                                                      vadEnabled:[Wit sharedInstance].detectSpeechStop withWitToken:[WITState sharedInstance].accessToken
@@ -53,7 +53,6 @@
 
     self.recordingSession.customData = customData;
     self.recordingSession.delegate = self;
-    //[self.recordingSession start];
 }
 
 - (void)stop{
@@ -114,7 +113,7 @@
 
     
     [req setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
-    [req setTimeoutInterval:15.0];
+    [req setTimeoutInterval:30];
     [req setValue:[NSString stringWithFormat:@"Bearer %@", self.accessToken] forHTTPHeaderField:@"Authorization"];
     [req setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [req setValue:@"application/json" forHTTPHeaderField:@"Accept"];
@@ -344,9 +343,9 @@
 }
 
 
-- (void)recordingSessionDidRecognizePreviewText:(NSString *)previewText {
-    if ([self.delegate respondsToSelector:@selector(witDidRecognizePreviewText:)]) {
-        [self.delegate witDidRecognizePreviewText: (NSString *) previewText];
+- (void)recordingSessionDidRecognizePreviewText:(NSString *)previewText final: (BOOL) isFinal {
+    if ([self.delegate respondsToSelector:@selector(witDidRecognizePreviewText:final:)]) {
+        [self.delegate witDidRecognizePreviewText: (NSString *) previewText final: isFinal];
     }
 }
 - (void)recordingSessionDidDetectSpeech {

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -261,7 +261,14 @@
 }
 
 - (void)error:(NSError*)e customData:(id)customData; {
-    [self.delegate witDidGraspIntent:nil messageId:nil customData:customData error:e];
+    if ([customData isKindOfClass:[WitSession class]]) {
+        [self.delegate didReceiveConverseError:e witSession:customData];
+    } else {
+        if ([self.delegate respondsToSelector:@selector(witDidGraspIntent:messageId:customData:error:)]) {
+            [self.delegate witDidGraspIntent:nil messageId:nil customData:customData error:e];
+        }
+    }
+    
 }
 
 #pragma mark - Getters and setters

--- a/Wit/Wit.m
+++ b/Wit/Wit.m
@@ -93,7 +93,7 @@
     NSDictionary *context = session.context;
     NSDate *start = [NSDate date];
 
-    NSString *urlString = [NSString stringWithFormat:@"https://api.wit.ai/converse?session_id=%@&v=%@", session.sessionID, kWitAPIVersion];
+    NSString *urlString = [NSString stringWithFormat:@"https://api.wit.ai/converse?session_id=%@&v=%@&verbose=true", session.sessionID, kWitAPIVersion];
     if (string) {
         urlString = [urlString stringByAppendingString:[NSString stringWithFormat:@"&q=%@", urlencodeString(string)]];
     }

--- a/WitTests/WitTests.m
+++ b/WitTests/WitTests.m
@@ -12,6 +12,7 @@
 @interface WitTests : XCTestCase <WitDelegate> {
     XCTestExpectation *stringInterpretedExpectation;
     XCTestExpectation *converseExpectation;
+    XCTestExpectation *converseErrorExpectation;
 }
 
 
@@ -62,6 +63,13 @@
     [converseExpectation fulfill];
     
 }
+
+- (void)didReceiveConverseError:(NSError *)error witSession:(WitSession *)session {
+    XCTAssert(session != nil, @"got no session information, error");
+    XCTAssert(error != nil, @"got no error information, error");
+    [converseErrorExpectation fulfill];
+    
+}
 - (void)testStringIntent {
     [Wit sharedInstance].accessToken = @"TFMXQC4W5PKGPONSMX2LRBR3BZ44XSWK";
     [Wit sharedInstance].delegate = self;
@@ -84,6 +92,23 @@
     [Wit sharedInstance].delegate = self;
     
     converseExpectation = [self expectationWithDescription:@"gotGetLocation"];
+    WitSession *session = [[WitSession alloc] initWithSessionID:[[NSUUID UUID] UUIDString]];
+    [[Wit sharedInstance] converseWithString:@"Where is the nearest Starbucks?" witSession:session];
+    
+    // The test will pause here, running the run loop, until the timeout is hit
+    // or all expectations are fulfilled.
+    [self waitForExpectationsWithTimeout:15 handler:^(NSError *error) {
+        
+    }];
+    
+}
+
+- (void)testConverseError {
+    
+    [Wit sharedInstance].accessToken = @"CDK44N5OBSB7WRDQ7ZQA53A6GK3ZJGVRZ"; //wrong access token to test converse error
+    [Wit sharedInstance].delegate = self;
+    
+    converseErrorExpectation = [self expectationWithDescription:@"waitingForError"];
     WitSession *session = [[WitSession alloc] initWithSessionID:[[NSUUID UUID] UUIDString]];
     [[Wit sharedInstance] converseWithString:@"Where is the nearest Starbucks?" witSession:session];
     


### PR DESCRIPTION
This PR adds speech recognition for the converse endpoint. To use it, set a WitSession to the new WitButton.session property. This only works with iOS 10 and above.

Also includes changes based on #25, a new error delegate based on comments from @klintan to #74, timeout improvements, preview recognition text improvements and a bit of code clean aup.